### PR TITLE
ip link set wlan0 down ahead

### DIFF
--- a/create_ap
+++ b/create_ap
@@ -338,6 +338,9 @@ EOF
 fi
 
 # initialize WiFi interface
+if [[ "$WIFI_IFACE" != "$INTERNET_IFACE" ]]; then
+    ip link set down dev ${WIFI_IFACE} || die
+fi
 ip link set down dev ${VWIFI_IFACE} || die
 ip addr flush ${VWIFI_IFACE} || die
 if [[ "$SHARE_METHOD" != "bridge" ]]; then


### PR DESCRIPTION
at line 341,
`ip link set down dev ${VWIFI_IFACE} || die`
should be added to
`ip link set down dev ${VWIFI_IFACE} || die
ip link set down dev ${WIFI_IFACE} || die`
because at least on my machine, interface wlp5s0(just like wlan0) will be set up when wicd start(when X start).
therefore an error occurs
`RTNETLINK answers: Name not unique on network`
thank you
