### PR TITLE
Update service file to fix cleaning process when service is requested to stop

### DIFF
--- a/create_ap.service
+++ b/create_ap.service
@@ -4,6 +4,7 @@ Description=Create AP Service
 [Service]
 Type=simple
 ExecStart=/usr/bin/bash create_ap -n -g 10.0.0.1 wlan0 AccessPointSSID
+ExecStop=pkill hostapd
 KillSignal=SIGINT
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
Inserted the ExecStop directive to kill the hostapd process in order to the script to be able to receive the SIGINT signal. This enables the cleaning process to work when requesting the service to stop.
