### PR TITLE
Solve "driver init failed" error caused by hostapd

### DIFF
--- a/create_ap
+++ b/create_ap
@@ -438,6 +438,10 @@ EOF
     [[ $ETC_HOSTS -eq 0 ]] && echo no-hosts >> $CONFDIR/dnsmasq.conf
 fi
 
+# To solve problems introduced by a bug in hostapd 2.1
+nmcli nm wifi off > /dev/null 2>&1
+rfkill unblock wlan > /dev/null 2>&1
+
 # initialize WiFi interface
 if [[ $NO_VIRT -eq 0 ]]; then
     ip link set dev ${WIFI_IFACE} address ${NEW_MACADDR} || die "$VIRTDIEMSG"


### PR DESCRIPTION
Hostapd v2 introduces a bug which currently throws the following error
and initialization fails
    nl80211: Could not configure driver mode
    nl80211 driver initialization failed.
    hostapd_free_hapd_data: Interface wlp3s0ap wasn't started

More Info: https://bugs.launchpad.net/ubuntu/+source/wpa/+bug/1289047
