### PR TITLE
Give remedial suggestion for hostapd bug

### DIFF
--- a/create_ap
+++ b/create_ap
@@ -79,11 +79,18 @@ get_new_macaddr() {
 
 ADDED_UNMANAGED=0
 NETWORKMANAGER_CONF=/etc/NetworkManager/NetworkManager.conf
+NMCLI_OLDER_VERSION=true
+NMCLI_RADIO_OBJ=nm
+
+[[ $(nmcli -v | awk '{print $4}') =~ ([0-9]*)\.([0-9*]\.[0-9]*)\.[0-9]* ]] && echo "${BASH_REMATCH[1]}"; echo "${BASH_REMATCH[2]}"; NMCLI_PRI_VER="${BASH_REMATCH[1]}"; NMCLI_SEC_VER="${BASH_REATCH[2]}"
+awk -v pri_ver="$NMCLI_PRI_VER" -v sec_ver="$NMCLI_SEC_VER" \
+    'BEGIN {if (pri_ver == 0 && sec_ver < 9.10) exit 1;}' \
+    || NMCLI_OLDER_VERSION=false; NMCLI_RADIO_OBJ=radio
 
 networkmanager_is_running() {
     which nmcli > /dev/null 2>&1 || return 1
     NMCLI_OUT=$(nmcli -t -f RUNNING g 2> /dev/null)
-    [[ $? -ne 0 ]] && NMCLI_OUT=$(nmcli -t -f RUNNING nm 2> /dev/null)
+    [[ $? -ne 0 ]] && NMCLI_OUT=$(nmcli -t -f RUNNING $NMCLI_RADIO_OBJ 2> /dev/null)
     [[ "$NMCLI_OUT" == "running" ]]
 }
 
@@ -488,10 +495,10 @@ fi
 echo "hostapd command-line interface: hostapd_cli -p $CONFDIR/hostapd_ctrl"
 trap - SIGINT # reset trap
 
-if ! hostapd $CONFDIR/hostapd.conf; then 
-    echo -e "\nError: Failed to run hostapd, maybe a program is interfering."
-    echo -e "\nIf an error like 'n80211: Could not configure driver mode' was thrown, it is probably becasue of a bug in hostapd."
-    echo "Try running 'nmcli nm wifi off; rfkill unblock wlan' before starting create_ap."
+if ! hostapd $CONFDIR/hostapd.conf && networkmanager_is_running; then 
+    echo -e "\nError: Failed to run hostapd, maybe a program is interfering." >&2
+    echo -e "\nIf an error like 'n80211: Could not configure driver mode' was thrown, it is probably becasue of a bug in hostapd." >&2
+    echo "Try running 'nmcli $NMCLI_RADIO_OBJ wifi off; rfkill unblock wlan' before starting create_ap." >&2
     die
 fi
 


### PR DESCRIPTION
Hostapd v2 introduces a bug which currently throws the following error
and initialization fails
    nl80211: Could not configure driver mode
    nl80211 driver initialization failed.
    hostapd_free_hapd_data: Interface wlp3s0ap wasn't started

More Info: https://bugs.launchpad.net/ubuntu/+source/wpa/+bug/1289047

Give a suggestive message to the user when hostapd fails because of the
above bug outlining the workaround mentioned in the above bug report.
