### PR TITLE
Fix virtual interface auto-renaming

### DIFF
--- a/create_ap
+++ b/create_ap
@@ -196,6 +196,17 @@ get_avail_bridge() {
     done
 }
 
+get_virt_iface_name() {
+    i=0
+    while :; do
+        if [[ ! -d /sys/class/net/ap${i} ]]; then
+            echo ap${i}
+            break
+        fi
+        i=$((i+1))
+    done
+}
+
 get_new_macaddr() {
     OLDMAC=$(get_macaddr "$1")
     for i in {20..255}; do
@@ -654,14 +665,7 @@ CONFDIR=$(mktemp -d /tmp/create_ap.${WIFI_IFACE}.conf.XXXXXXXX)
 echo "Config dir: $CONFDIR"
 
 if [[ $NO_VIRT -eq 0 ]]; then
-    i=0
-    while :; do
-        if [[ ! -d /sys/class/net/ap${i} ]]; then
-            VWIFI_IFACE=ap${i}
-            break
-        fi
-        i=$((i+1))
-    done
+    VWIFI_IFACE=$(get_virt_iface_name)
 
     # in NetworkManager 0.9.10 and above we can set the interface as unmanaged without
     # the need of MAC address, so we set it before we create the virtual interface.


### PR DESCRIPTION
In some Linux distributions (e.g. Ubuntu, Debian), udev automatically renames any device with its name prefix is "eth_", "wlan_",... as declared in "/lib/udev/rules.d/75-persistent-net-generator.rules". This made a problem when creating a virtual device on these distributions declaring that device not found. Solution was to change virtual device's name prefix to "ap*" to avoid this collision.
