### PR TITLE
Redirect --help output to stdout instead of stderr

### DIFF
--- a/create_ap
+++ b/create_ap
@@ -612,7 +612,7 @@ eval set -- "$GETOPT_ARGS"
 while :; do
     case "$1" in
         -h|--help)
-            usage >&2
+            usage
             exit 1
             ;;
         --version)


### PR DESCRIPTION
The normal expected behaviour for output from --help option is to get it in stdout. Today, I used the --help option and redirected the output to less, to find the screen empty. Took me a while to realize that the output is being redirected to stderr.

I'm sure others might also get confused by this.