### PR TITLE
Ensure error code is 0 when --help is invoked

### DIFF
--- a/create_ap
+++ b/create_ap
@@ -613,7 +613,7 @@ while :; do
     case "$1" in
         -h|--help)
             usage
-            exit 1
+            exit 0
             ;;
         --version)
             echo $VERSION


### PR DESCRIPTION
This should have been taken care of in pull request #64 itself, but somehow got missed.