### PR TITLE
User config

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -128,6 +128,9 @@ _create_ap() {
         --mkconfig)
             _use_filedir && return 0
             ;;
+        --config)
+            _use_filedir && return 0
+            ;;
         -g)
             # Not going to implement
             ;;

--- a/bash_completion
+++ b/bash_completion
@@ -111,7 +111,8 @@ _create_ap() {
             # No Options
             ;;
         --stop)
-            opts=$("$1" --list)
+            local stop_awk_cmd='$1 ~ /^[0-9]+$/'
+            opts=$("$1" --list | awk "$stop_awk_cmd")
             ;;
         --list)
             # No Options

--- a/bash_completion
+++ b/bash_completion
@@ -2,6 +2,14 @@
 # Bash Completion routine for create_ap
 #
 
+_use_filedir() {
+    if [[ $(type -t _filedir) == "function" ]]; then
+        _filedir
+        return 0
+    fi
+    return 1
+}
+
 _create_ap() {
     local awk_cmd='
         ($1 ~ /^-/) {
@@ -116,6 +124,9 @@ _create_ap() {
             ;;
         --list)
             # No Options
+            ;;
+        --mkconfig)
+            _use_filedir && return 0
             ;;
         -g)
             # Not going to implement

--- a/create_ap
+++ b/create_ap
@@ -58,6 +58,7 @@ usage() {
     echo "                          get them with --list"
     echo "  --list                  Show the create_ap processes that are already running"
     echo "  --mkconfig <conf_file>  Store configs in conf_file"
+    echo "  --config <conf_file>    Load configs from conf_file"
     echo
     echo "Non-Bridging Options:"
     echo "  -g <gateway>            IPv4 Gateway for the Access Point (default: 192.168.12.1)"
@@ -590,6 +591,9 @@ LIST_RUNNING=0
 STOP_ID=
 
 STORE_CONFIG=
+LOAD_CONFIG=
+
+declare -A LOADED_ARGS
 
 CONFDIR=
 WIFI_IFACE=
@@ -837,8 +841,61 @@ write_config() {
     exit 0
 }
 
+is_config_opt() {
+    local elem opt="$1"
+
+    for elem in "${CONFIG_OPTS[@]}"; do
+        if [[ "$elem" == "$opt" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Load options from config file
+read_config() {
+    local opt_name opt_val
+    local pos_max=0 pos_num=0 pos_idx
+
+    while read line; do
+        # Read switches and their values
+        opt_name="${line%=*}"
+        opt_val="${line#*=}"
+        if is_config_opt "$opt_name" ; then
+            eval $opt_name="\$opt_val"
+        elif [[ "$opt_name" =~ ^ARG([1-9][0-9]*)$ ]]; then
+            pos_idx="${BASH_REMATCH[1]}"
+            ((pos_num++))
+            [[ $pos_idx > $pos_max ]] && pos_max=$pos_idx
+            LOADED_ARGS[$pos_idx]="$opt_val"
+        else
+            echo "WARN: Unrecognized configuration entry $opt_name" >&2
+        fi
+    done < "$LOAD_CONFIG"
+
+    if [[ $pos_num -ne $pos_max ]]; then
+        echo "ERROR: Positional arguments cannot be skipped" >&2
+        exit 1
+    fi
+}
+
+
 ARGS=( "$@" )
-GETOPT_ARGS=$(getopt -o hc:w:g:dnm: -l "help","hidden","ieee80211n","ht_capab:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","daemon","stop:","list","version","no-haveged","mkconfig:" -n "$PROGNAME" -- "$@")
+# Preprocessing for --config before option-parsing starts
+for ((i=0; i<$#; i++)); do
+    if [[ "${ARGS[i]}" = "--config" ]]; then
+        if [[ -f "${ARGS[i+1]}" ]]; then
+            LOAD_CONFIG="${ARGS[i+1]}"
+            read_config
+        else
+            echo "ERROR: No config file found at given location" >&2
+            exit 1
+        fi
+        break
+    fi
+done
+
+GETOPT_ARGS=$(getopt -o hc:w:g:dnm: -l "help","hidden","ieee80211n","ht_capab:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","daemon","stop:","list","version","no-haveged","mkconfig:","config:" -n "$PROGNAME" -- "$@")
 [[ $? -ne 0 ]] && exit 1
 eval set -- "$GETOPT_ARGS"
 
@@ -944,12 +1001,25 @@ while :; do
             STORE_CONFIG="$1"
             shift
             ;;
+        --config)
+            shift
+            shift
+            ;;
         --)
             shift
             break
             ;;
     esac
 done
+
+# Load positional args from config file, if needed
+if [[ -n "$LOAD_CONFIG" ]]; then
+    for ((i=$# + 1; i<=${#LOADED_ARGS[@]}; i++)); do
+        ((j=i-1))
+        ((k=i+1))
+        set -- "${@:1:$j}" "${LOADED_ARGS[$i]}" "${@:$k}"
+    done
+fi
 
 # Check if required number of positional args are present
 if [[ $# -lt 1 && $FIX_UNMANAGED -eq 0  && -z "$STOP_ID" && $LIST_RUNNING -eq 0 ]]; then

--- a/create_ap
+++ b/create_ap
@@ -30,37 +30,38 @@ usage() {
     echo "Usage: "$PROGNAME" [options] <wifi-interface> [<interface-with-internet>] [<access-point-name> [<passphrase>]]"
     echo
     echo "Options:"
-    echo "  -h, --help          Show this help"
-    echo "  --version           Print version number"
-    echo "  -c <channel>        Channel number (default: 1)"
-    echo "  -w <WPA version>    Use 1 for WPA, use 2 for WPA2, use 1+2 for both (default: 1+2)"
-    echo "  -n                  Disable Internet sharing (if you use this, don't pass"
-    echo "                      the <interface-with-internet> argument)"
-    echo "  -m <method>         Method for Internet sharing."
-    echo "                      Use: 'nat' for NAT (default)"
-    echo "                           'bridge' for bridging"
-    echo "                           'none' for no Internet sharing (equivalent to -n)"
-    echo "  --hidden            Make the Access Point hidden (do not broadcast the SSID)"
-    echo "  --ieee80211n        Enable IEEE 802.11n (HT)"
-    echo "  --ht_capab <HT>     HT capabilities (default: [HT40+])"
-    echo "  --country <code>    Set two-letter country code for regularity (example: US)"
-    echo "  --freq-band <GHz>   Set frequency band. Valid inputs: 2.4, 5 (default: 2.4)"
-    echo "  --driver            Choose your WiFi adapter driver (default: nl80211)"
-    echo "  --no-virt           Do not create virtual interface"
-    echo "  --no-haveged        Do not run 'haveged' automatically when needed"
-    echo "  --fix-unmanaged     If NetworkManager shows your interface as unmanaged after you"
-    echo "                      close create_ap, then use this option to switch your interface"
-    echo "                      back to managed"
-    echo "  --mac <MAC>         Set MAC address"
-    echo "  --daemon            Run create_ap in the background"
-    echo "  --stop <id>         Send stop command to an already running create_ap. For an <id>"
-    echo "                      you can put the PID of create_ap or the WiFi interface. You can"
-    echo "                      get them with --list"
-    echo "  --list              Show the create_ap processes that are already running"
+    echo "  -h, --help              Show this help"
+    echo "  --version               Print version number"
+    echo "  -c <channel>            Channel number (default: 1)"
+    echo "  -w <WPA version>        Use 1 for WPA, use 2 for WPA2, use 1+2 for both (default: 1+2)"
+    echo "  -n                      Disable Internet sharing (if you use this, don't pass"
+    echo "                          the <interface-with-internet> argument)"
+    echo "  -m <method>             Method for Internet sharing."
+    echo "                          Use: 'nat' for NAT (default)"
+    echo "                               'bridge' for bridging"
+    echo "                               'none' for no Internet sharing (equivalent to -n)"
+    echo "  --hidden                Make the Access Point hidden (do not broadcast the SSID)"
+    echo "  --ieee80211n            Enable IEEE 802.11n (HT)"
+    echo "  --ht_capab <HT>         HT capabilities (default: [HT40+])"
+    echo "  --country <code>        Set two-letter country code for regularity (example: US)"
+    echo "  --freq-band <GHz>       Set frequency band. Valid inputs: 2.4, 5 (default: 2.4)"
+    echo "  --driver                Choose your WiFi adapter driver (default: nl80211)"
+    echo "  --no-virt               Do not create virtual interface"
+    echo "  --no-haveged            Do not run 'haveged' automatically when needed"
+    echo "  --fix-unmanaged         If NetworkManager shows your interface as unmanaged after you"
+    echo "                          close create_ap, then use this option to switch your interface"
+    echo "                          back to managed"
+    echo "  --mac <MAC>             Set MAC address"
+    echo "  --daemon                Run create_ap in the background"
+    echo "  --stop <id>             Send stop command to an already running create_ap. For an <id>"
+    echo "                          you can put the PID of create_ap or the WiFi interface. You can"
+    echo "                          get them with --list"
+    echo "  --list                  Show the create_ap processes that are already running"
+    echo "  --mkconfig <conf_file>  Store configs in conf_file"
     echo
     echo "Non-Bridging Options:"
-    echo "  -g <gateway>        IPv4 Gateway for the Access Point (default: 192.168.12.1)"
-    echo "  -d                  DNS server will take into account /etc/hosts"
+    echo "  -g <gateway>            IPv4 Gateway for the Access Point (default: 192.168.12.1)"
+    echo "  -d                      DNS server will take into account /etc/hosts"
     echo
     echo "Useful informations:"
     echo "  * If you're not using the --no-virt option, then you can create an AP with the same"
@@ -574,14 +575,21 @@ IEEE80211N=0
 HT_CAPAB='[HT40+]'
 DRIVER=nl80211
 NO_VIRT=0
-FIX_UNMANAGED=0
 COUNTRY=
 FREQ_BAND=2.4
 NEW_MACADDR=
 DAEMONIZE=0
+NO_HAVEGED=0
+
+CONFIG_OPTS=(CHANNEL GATEWAY WPA_VERSION ETC_HOST HIDDEN SHARE_METHOD
+             IEEE80211N HT_CAPAB DRIVER NO_VIRT COUNTRY FREQ_BAND
+             NEW_MACADDR DAEMONIZE NO_HAVEGED)
+
+FIX_UNMANAGED=0
 LIST_RUNNING=0
 STOP_ID=
-NO_HAVEGED=0
+
+STORE_CONFIG=
 
 CONFDIR=
 WIFI_IFACE=
@@ -806,8 +814,31 @@ send_stop() {
     mutex_unlock
 }
 
+# Storing configs
+write_config() {
+    local i=1
+
+    if ! eval 'echo -n > "$STORE_CONFIG"' > /dev/null 2>&1; then
+        echo "ERROR: Unable to create config file $STORE_CONFIG" >&2
+        exit 1
+    fi
+
+    for config_opt in "${CONFIG_OPTS[@]}"; do
+        eval echo $config_opt=\$$config_opt
+    done >> "$STORE_CONFIG"
+
+    while [[ $# -ne 0 ]]; do
+        echo "ARG$i=$1"
+        shift
+        ((i++))
+    done >> "$STORE_CONFIG"
+
+    echo -e "\nConfigs written to $STORE_CONFIG"
+    exit 0
+}
+
 ARGS=( "$@" )
-GETOPT_ARGS=$(getopt -o hc:w:g:dnm: -l "help","hidden","ieee80211n","ht_capab:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","daemon","stop:","list","version","no-haveged" -n "$PROGNAME" -- "$@")
+GETOPT_ARGS=$(getopt -o hc:w:g:dnm: -l "help","hidden","ieee80211n","ht_capab:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","daemon","stop:","list","version","no-haveged","mkconfig:" -n "$PROGNAME" -- "$@")
 [[ $? -ne 0 ]] && exit 1
 eval set -- "$GETOPT_ARGS"
 
@@ -908,6 +939,11 @@ while :; do
             shift
             NO_HAVEGED=1
             ;;
+        --mkconfig)
+            shift
+            STORE_CONFIG="$1"
+            shift
+            ;;
         --)
             shift
             break
@@ -933,6 +969,8 @@ fi
 trap "clean_exit" SIGINT SIGUSR1
 # if we get USR2 signal then run die().
 trap "die" SIGUSR2
+
+[[ -n "$STORE_CONFIG" ]] && write_config "$@"
 
 if [[ $LIST_RUNNING -eq 1 ]]; then
     echo -e "List of running $PROGNAME instances:\n"

--- a/create_ap
+++ b/create_ap
@@ -47,7 +47,7 @@ usage() {
     echo "  --freq-band <GHz>   Set frequency band. Valid inputs: 2.4, 5 (default: 2.4)"
     echo "  --driver            Choose your WiFi adapter driver (default: nl80211)"
     echo "  --no-virt           Do not create virtual interface"
-    echo "  --no-haveged        Do not run \`haveged' automatically when needed"
+    echo "  --no-haveged        Do not run 'haveged' automatically when needed"
     echo "  --fix-unmanaged     If NetworkManager shows your interface as unmanaged after you"
     echo "                      close create_ap, then use this option to switch your interface"
     echo "                      back to managed"
@@ -915,6 +915,7 @@ while :; do
     esac
 done
 
+# Check if required number of positional args are present
 if [[ $# -lt 1 && $FIX_UNMANAGED -eq 0  && -z "$STOP_ID" && $LIST_RUNNING -eq 0 ]]; then
     usage >&2
     exit 1
@@ -934,6 +935,7 @@ trap "clean_exit" SIGINT SIGUSR1
 trap "die" SIGUSR2
 
 if [[ $LIST_RUNNING -eq 1 ]]; then
+    echo -e "List of running $PROGNAME instances:\n"
     list_running
     exit 0
 fi
@@ -944,11 +946,13 @@ if [[ $(id -u) -ne 0 ]]; then
 fi
 
 if [[ -n "$STOP_ID" ]]; then
+    echo "Trying to kill $PROGNAME instance associated with $STOP_ID..."
     send_stop "$STOP_ID"
     exit 0
 fi
 
 if [[ $FIX_UNMANAGED -eq 1 ]]; then
+    echo "Trying to fix unmanaged status in NetworkManager..."
     networkmanager_fix_unmanaged
     exit 0
 fi
@@ -959,6 +963,7 @@ if [[ $DAEMONIZE -eq 1 ]]; then
     for x in "${ARGS[@]}"; do
         [[ "$x" != "--daemon" ]] && NEW_ARGS+=( "$x" )
     done
+    echo "Running as Daemon..."
 
     # run a detached create_ap
     setsid "$0" "${NEW_ARGS[@]}" &


### PR DESCRIPTION
* Support --config and --mkconfig options.
* Other options can be given alongwith --config and the options on the command line will override the ones in the config file.
* When --config and --mkconfig are given together alongwith other options, the net of all options (those on command-line and from the config file) are written into the new config file given by --mkconfig.
* This should partially solve #69 