### PR TITLE
Added some functions

### DIFF
--- a/create_ap
+++ b/create_ap
@@ -42,6 +42,8 @@ usage() {
     echo "                               'none' for no Internet sharing (equivalent to -n)"
     echo "  --psk                   Use 64 hex digits pre-shared-key instead of passphrase"
     echo "  --hidden                Make the Access Point hidden (do not broadcast the SSID)"
+    echo "  --redirect-to-localhost If -n is set, redirect every web request to localhost (useful for public information networks)"
+    echo "  --hostapd-debug <level> With level between 1 and 2, passes arguments -d or -dd to hostapd for debugging."
     echo "  --isolate-clients       Disable communication between clients"
     echo "  --ieee80211n            Enable IEEE 802.11n (HT)"
     echo "  --ht_capab <HT>         HT capabilities (default: [HT40+])"
@@ -599,6 +601,8 @@ DAEMONIZE=0
 NO_HAVEGED=0
 USE_PSK=0
 
+HOSTAPD_DEBUG_ARGS=
+REDIRECT_TO_LOCALHOST=0
 
 CONFIG_OPTS=(CHANNEL GATEWAY WPA_VERSION ETC_HOSTS DHCP_DNS NO_DNS HIDDEN ISOLATE_CLIENTS SHARE_METHOD
              IEEE80211N HT_CAPAB DRIVER NO_VIRT COUNTRY FREQ_BAND
@@ -988,7 +992,7 @@ for ((i=0; i<$#; i++)); do
     fi
 done
 
-GETOPT_ARGS=$(getopt -o hc:w:g:dnm: -l "help","hidden","isolate-clients","ieee80211n","ht_capab:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","dhcp-dns:","daemon","stop:","list","list-running","list-clients:","version","psk","no-haveged","no-dns","mkconfig:","config:" -n "$PROGNAME" -- "$@")
+GETOPT_ARGS=$(getopt -o hc:w:g:dnm: -l "help","hidden","hostapd-debug:","redirect-to-localhost","isolate-clients","ieee80211n","ht_capab:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","dhcp-dns:","daemon","stop:","list","list-running","list-clients:","version","psk","no-haveged","no-dns","mkconfig:","config:" -n "$PROGNAME" -- "$@")
 [[ $? -ne 0 ]] && exit 1
 eval set -- "$GETOPT_ARGS"
 
@@ -1115,6 +1119,22 @@ while :; do
         --no-dns)
             shift
             NO_DNS=1
+            ;;
+        --redirect-to-localhost)
+            shift
+            REDIRECT_TO_LOCALHOST=1
+            ;;
+        --hostapd-debug)
+            shift
+            if [ "x$1" = "x1" ]; then
+                HOSTAPD_DEBUG_ARGS="-d"
+            elif [ "x$1" = "x2" ]; then
+                HOSTAPD_DEBUG_ARGS="-dd"
+            else
+                printf "Error: argument for --hostapd-debug expected 1 or 2, got %s\n" "$1"
+                exit 1
+            fi
+            shift
             ;;
         --mkconfig)
             shift
@@ -1561,6 +1581,11 @@ EOF
     MTU=$(get_mtu $INTERNET_IFACE)
     [[ -n "$MTU" ]] && echo "dhcp-option-force=option:mtu,${MTU}" >> $CONFDIR/dnsmasq.conf
     [[ $ETC_HOSTS -eq 0 ]] && echo no-hosts >> $CONFDIR/dnsmasq.conf
+    if [[ "$SHARE_METHOD" == "none" && "$REDIRECT_TO_LOCALHOST" == "1" ]]; then
+        cat << EOF >> $CONFDIR/dnsmasq.conf
+address=/#/$GATEWAY
+EOF
+    fi
 fi
 
 # initialize WiFi interface
@@ -1696,8 +1721,8 @@ if [[ $NO_HAVEGED -eq 0 ]]; then
     HAVEGED_WATCHDOG_PID=$!
 fi
 
-# start hostapd
-hostapd $CONFDIR/hostapd.conf &
+# start hostapd (use stdbuf for no delayed output in porgrams that redirect stdout)
+stdbuf -oL hostapd $HOSTAPD_DEBUG_ARGS $CONFDIR/hostapd.conf &
 HOSTAPD_PID=$!
 echo $HOSTAPD_PID > $CONFDIR/hostapd.pid
 


### PR DESCRIPTION
create_ap can now redirect all web requests to the access point (useful when running a web server) and pass debug argument -d or -dd to hostapd. It also doesn't act funny with applications running it that redirect stdout (delayed output).

enjoy :)