### PR TITLE
Add default interface option

### DIFF
--- a/create_ap
+++ b/create_ap
@@ -1404,6 +1404,14 @@ else
     fi
 fi
 
+if [[ $INTERNET_IFACE == 'default' ]]; then
+    INTERNET_IFACE="$(ip route | awk '/default/ { print $5 }')"
+    if [[ -z $INTERNET_IFACE ]]; then
+        echo "ERROR: default route doesn't exist" >&2
+        exit 1
+    fi
+fi
+
 if [[ "$SHARE_METHOD" != "none" ]] && ! is_interface $INTERNET_IFACE; then
     echo "ERROR: '${INTERNET_IFACE}' is not an interface" >&2
     exit 1


### PR DESCRIPTION
I'm often sharing internet from different interfaces. Every time I switch between GSM modem and USB ethernet, I must change interface name in configuration file.
This code helps, because when I switch, I only have to start create_ap. It checks which interface has the default route in system and sets it as $INTERNET_IFACE. It runs when <interface-with-internet> option is set to "default". There's a possible conflict, when someone has interface named "default". 