### PR TITLE
Feature/address reservation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@
 ### Client Isolation:
     create_ap --isolate-clients wlan0 eth0 MyAccessPoint MyPassPhrase
 
+### IP address reservation
+    create_ap --dhcp-hosts ./dhcp_hosts.conf MyAccessPoint MyPassPhrase
+
 ## Systemd service
 Using the persistent [systemd](https://wiki.archlinux.org/index.php/systemd#Basic_systemctl_usage) service
 ### Start service immediately:

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@
 ### Client Isolation:
     create_ap --isolate-clients wlan0 eth0 MyAccessPoint MyPassPhrase
 
-### IP address reservation
-    create_ap --dhcp-hosts ./dhcp_hosts.conf MyAccessPoint MyPassPhrase
+### IP address reservation (See [howto](howto/dhcp_address_reservation.md))
+    create_ap --dhcp-hosts ./dhcp_hosts.conf -g 192.168.1.1 MyAccessPoint MyPassPhrase
 
 ## Systemd service
 Using the persistent [systemd](https://wiki.archlinux.org/index.php/systemd#Basic_systemctl_usage) service

--- a/bash_completion
+++ b/bash_completion
@@ -138,6 +138,9 @@ _create_ap() {
         --dhcp-dns)
             # Not going to implement
             ;;
+        --dhcp-hosts)
+            _use_filedir && return 0
+            ;;
         --mkconfig)
             _use_filedir && return 0
             ;;

--- a/create_ap
+++ b/create_ap
@@ -59,6 +59,7 @@ usage() {
     echo "                          back to managed"
     echo "  --mac <MAC>             Set MAC address"
     echo "  --dhcp-dns <IP1[,IP2]>  Set DNS returned by DHCP"
+    echo "  --dhcp-hosts <file>     Load DHCP address reservation list from file"
     echo "  --daemon                Run create_ap in the background"
     echo "  --stop <id>             Send stop command to an already running create_ap. For an <id>"
     echo "                          you can put the PID of create_ap or the WiFi interface. You can"
@@ -639,6 +640,7 @@ BRIDGE_IFACE=
 OLD_MACADDR=
 IP_ADDRS=
 ROUTE_ADDRS=
+DHCP_HOSTS=
 
 HAVEGED_WATCHDOG_PID=
 
@@ -1112,6 +1114,11 @@ while :; do
         --dhcp-dns)
             shift
             DHCP_DNS="$1"
+            shift
+            ;;
+        --dhcp-hosts)
+            shift
+            DHCP_HOSTS="$1"
             shift
             ;;
         --daemon)
@@ -1642,6 +1649,20 @@ EOF
         cat << EOF >> $CONFDIR/dnsmasq.conf
 address=/#/$GATEWAY
 EOF
+    fi
+    if [[ ! -z $DHCP_HOSTS ]]; then
+        if [[ ! -f $DHCP_HOSTS ]]; then
+            echo "ERROR: IP reservation list file ${DHCP_HOSTS} not found." >&2
+            exit 1
+        fi
+        while IFS='' read -r dhcp_assignment || [[ -n "$dhcp_assignment" ]]; do
+            [[ "$dhcp_assignment" =~ ^$ ]] && continue # Skip empty lines
+            [[ "$dhcp_assignment" =~ ^#.*$ ]] && continue # Skip comment lines
+            dhcp_host_entry="$( echo "$dhcp_assignment" | sed 's/#.*$//g')" # Remove trailing comments
+            dhcp_host_entry="$( echo "$dhcp_host_entry" | sed 's/[[:space:]][[:space:]]*/,/g')" # Change column separators to commas
+            dhcp_host_entry="$( echo "$dhcp_host_entry" | sed 's/\,$//')" # Remove any trailing commas
+            echo "dhcp-host=$dhcp_host_entry" >> CONFDIR/dnsmasq.conf
+        done < "$1"
     fi
 fi
 

--- a/create_ap
+++ b/create_ap
@@ -1661,8 +1661,8 @@ EOF
             dhcp_host_entry="$( echo "$dhcp_assignment" | sed 's/#.*$//g')" # Remove trailing comments
             dhcp_host_entry="$( echo "$dhcp_host_entry" | sed 's/[[:space:]][[:space:]]*/,/g')" # Change column separators to commas
             dhcp_host_entry="$( echo "$dhcp_host_entry" | sed 's/\,$//')" # Remove any trailing commas
-            echo "dhcp-host=$dhcp_host_entry" >> CONFDIR/dnsmasq.conf
-        done < "$1"
+            echo "dhcp-host=$dhcp_host_entry" >> $CONFDIR/dnsmasq.conf
+        done < "$DHCP_HOSTS"
     fi
 fi
 

--- a/create_ap
+++ b/create_ap
@@ -1014,7 +1014,7 @@ for ((i=0; i<$#; i++)); do
     fi
 done
 
-GETOPT_ARGS=$(getopt -o hc:w:g:dnm: -l "help","hidden","hostapd-debug:","redirect-to-localhost","isolate-clients","ieee80211n","ieee80211ac","ht_capab:","vht_capab:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","dhcp-dns:","daemon","stop:","list","list-running","list-clients:","version","psk","no-haveged","no-dns","mkconfig:","config:" -n "$PROGNAME" -- "$@")
+GETOPT_ARGS=$(getopt -o hc:w:g:dnm: -l "help","hidden","hostapd-debug:","redirect-to-localhost","isolate-clients","ieee80211n","ieee80211ac","ht_capab:","vht_capab:","driver:","no-virt","fix-unmanaged","country:","freq-band:","mac:","dhcp-dns:","dhcp-hosts:","daemon","stop:","list","list-running","list-clients:","version","psk","no-haveged","no-dns","mkconfig:","config:" -n "$PROGNAME" -- "$@")
 [[ $? -ne 0 ]] && exit 1
 eval set -- "$GETOPT_ARGS"
 

--- a/howto/dhcp_address_reservation.md
+++ b/howto/dhcp_address_reservation.md
@@ -1,0 +1,42 @@
+# DHCP address reservation
+
+In order to enable address reservation for selected hosts in your network, use `--dhcp-hosts <file_path>` option with a path to an address reservation file.
+
+The file should contain address reservation entries, one per line, compatible with the `dnsmasq` dhcp-host configuration option, with the exception that commas can be replaced with multiple spaces or tabs for nicer formatting.
+
+Also comments are supported either on independent lines or appended to the entry lines.
+
+Example configuration is presented below:
+
+```
+#
+# Laptops
+#
+00:1C:F0:A8:0A:11       192.168.1.100               # Alice's laptop
+00:26:BB:12:CC:22       192.168.1.101   infinite    # Bob's laptop (infite lease)
+00:26:BB:12:CC:33       192.168.1.101               # Jenny's laptop
+
+#
+# Mobiles
+#
+90:F6:52:06:65:44       192.168.1.102               # Alice's mobile
+80:1F:02:59:64:55       192.168.1.106               # Bob's mobile
+
+#
+# Other
+#
+C4:85:08:F3:A4:66       ignore                      # Disable DHCP for desktop
+```
+
+which produces the following entries in the `dnsmasq.conf`:
+
+```
+dhcp-host=00:1C:F0:A8:0A:11,192.168.1.100
+dhcp-host=00:26:BB:12:CC:22,192.168.1.101,infinite
+dhcp-host=00:26:BB:12:CC:33,192.168.1.101
+dhcp-host=90:F6:52:06:65:44,192.168.1.102
+dhcp-host=80:1F:02:59:64:55,192.168.1.106
+dhcp-host=C4:85:08:F3:A4:66,ignore
+```
+
+For more `dhcp-host` entry examples checkout [example configuration](http://oss.segetech.com/intra/srv/dnsmasq.conf).

--- a/howto/dhcp_address_reservation.md
+++ b/howto/dhcp_address_reservation.md
@@ -6,6 +6,8 @@ The file should contain address reservation entries, one per line, compatible wi
 
 Also comments are supported either on independent lines or appended to the entry lines.
 
+This feature should typically be used in combination with `-g` option to make sure that the assigned addresses in the configuration file are on the same network as the gateway.
+
 Example configuration is presented below:
 
 ```
@@ -39,4 +41,4 @@ dhcp-host=80:1F:02:59:64:55,192.168.1.106
 dhcp-host=C4:85:08:F3:A4:66,ignore
 ```
 
-For more `dhcp-host` entry examples checkout [example configuration](http://oss.segetech.com/intra/srv/dnsmasq.conf).
+For more `dhcp-host` entry format checkout `dnsmasq` [manpage](http://www.thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html).


### PR DESCRIPTION
@oblique Thanks for creating this tool.

I've added a simple extension to enable IP address reservation based on MAC addresses using a simple configuration file, which generates relevant `dhcp-host` entries in the output `dnsmasq.conf` file.

The idea is to enable users to specify the IP address reservation as simply as possible, while still maintaining full features of `dhcp-host` format.

The configuration file can be as simple as:
```
00:1C:F0:A8:0A:11  92.168.1.100 
00:1C:F0:A8:0A:12  92.168.1.101
```
but it can also include comments, empty lines, tabs, and all valid `dhcp-host` values, with the addition that instead of commas users can format this file as they want using spaces and tabs.

