### PR TITLE
Fixed makefile installation method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,21 @@
+PREFIX=/usr
+MANDIR=$(PREFIX)/share/man
+BINDIR=$(PREFIX)/bin
+
 all:
 	@echo "Run 'make install' for installation."
 	@echo "Run 'make uninstall' for uninstallation."
 
 install:
-	cp create_ap /usr/bin/create_ap
-	cp create_ap.conf /etc/create_ap.conf
-	[ ! -d /lib/systemd/system ] || cp create_ap.service /lib/systemd/system
-	mkdir -p /usr/share/bash-completion/completions
-	cp bash_completion /usr/share/bash-completion/completions/create_ap
+	install -Dm755 create_ap $(DESTDIR)$(BINDIR)/create_ap
+	install -Dm644 create_ap.conf $(DESTDIR)/etc/create_ap.conf
+	[ ! -d /lib/systemd/system ] || install -Dm644 create_ap.service $(DESTDIR)/lib/systemd/system/create_ap.service
+	install -Dm644 bash_completion $(DESTDIR)$(PREFIX)/share/bash-completion/completions/create_ap
+	install -Dm644 README.md $(DESTDIR)$(PREFIX)/share/doc/${pkgname}/README.md
 
 uninstall:
-	rm /usr/bin/create_ap
-	rm /etc/create_ap.conf
-	[ ! -f /lib/systemd/system/create_ap.service ] || rm /lib/systemd/system/create_ap.service
-	rm /usr/share/bash-completion/completions/create_ap
+	rm -f $(DESTDIR)$(BINDIR)/create_ap
+	rm -f $(DESTDIR)/etc/create_ap.conf
+	[ ! -f /lib/systemd/system/create_ap.service ] || rm -f $(DESTDIR)/lib/systemd/system/create_ap.service
+	rm -f $(DESTDIR)$(PREFIX)/share/bash-completion/completions/create_ap
+	rm -f $(DESTDIR)$(PREFIX)/share/doc/${pkgname}/README.md

--- a/create_ap
+++ b/create_ap
@@ -14,7 +14,7 @@
 #    dnsmasq
 #    iptables
 
-VERSION=0.4
+VERSION=0.4.1
 PROGNAME="$(basename $0)"
 
 # make sure that all command outputs are in english


### PR DESCRIPTION
This makes it way simpler to use the make inside a PKGBUILD to package create_ap. It uses `install` to set permissions properly and uses variables to change the destination dir.

See this as reference:
https://git.server-speed.net/users/flo/fb/tree/Makefile

It would be nice if you can tag a new release, as I've bumped the version number. I will then update the AUR package. create_ap will possibly move soon to community on archlinux.