### PR TITLE
Corrected systemd makefile path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,13 @@ all:
 install:
 	install -Dm755 create_ap $(DESTDIR)$(BINDIR)/create_ap
 	install -Dm644 create_ap.conf $(DESTDIR)/etc/create_ap.conf
-	[ ! -d /lib/systemd/system ] || install -Dm644 create_ap.service $(DESTDIR)/lib/systemd/system/create_ap.service
+	[ ! -d /lib/systemd/system ] || install -Dm644 create_ap.service $(DESTDIR)$(PREFIX)/lib/systemd/system/create_ap.service
 	install -Dm644 bash_completion $(DESTDIR)$(PREFIX)/share/bash-completion/completions/create_ap
 	install -Dm644 README.md $(DESTDIR)$(PREFIX)/share/doc/${pkgname}/README.md
 
 uninstall:
 	rm -f $(DESTDIR)$(BINDIR)/create_ap
 	rm -f $(DESTDIR)/etc/create_ap.conf
-	[ ! -f /lib/systemd/system/create_ap.service ] || rm -f $(DESTDIR)/lib/systemd/system/create_ap.service
+	[ ! -f /lib/systemd/system/create_ap.service ] || rm -f $(DESTDIR)$(PREFIX)/lib/systemd/system/create_ap.service
 	rm -f $(DESTDIR)$(PREFIX)/share/bash-completion/completions/create_ap
 	rm -f $(DESTDIR)$(PREFIX)/share/doc/${pkgname}/README.md

--- a/create_ap
+++ b/create_ap
@@ -14,7 +14,7 @@
 #    dnsmasq
 #    iptables
 
-VERSION=0.4.1
+VERSION=0.4.2
 PROGNAME="$(basename $0)"
 
 # make sure that all command outputs are in english


### PR DESCRIPTION
Sorry for that one...

I left out the license as that should be part of the PKGBUILD I think. Otherwise you could also install it to: `install -Dm 644 "${pkgname}-${pkgver}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"`