### PR TITLE
can_be_sta_and_ap() regexp fix

### DIFF
--- a/create_ap
+++ b/create_ap
@@ -279,7 +279,7 @@ get_adapter_kernel_module() {
 can_be_sta_and_ap() {
     # iwconfig does not provide this information, assume false
     [[ $USE_IWCONFIG -eq 1 ]] && return 1
-    get_adapter_info "$1"  | sed -r 's/.*\{.* AP.*\} *<= *([0-9]*).*/\1/g' | sed -r 's/([0-9]*).*/\1/g' | awk '$1 > 1' > /dev/null 2>&1 && return 0
+    get_adapter_info "$1"  | sed -r 's/.*\{.* AP.*\} *<= *([0-9]*).*/\1/g' | sed -r 's/([0-9]*).*/\1/g' | awk '$1 > 1' | grep -E '[0-9*]' > /dev/null 2>&1 && return 0
     return 1
 }
 

--- a/create_ap
+++ b/create_ap
@@ -279,8 +279,7 @@ get_adapter_kernel_module() {
 can_be_sta_and_ap() {
     # iwconfig does not provide this information, assume false
     [[ $USE_IWCONFIG -eq 1 ]] && return 1
-    get_adapter_info "$1" | grep -E '{.* managed.* AP.*}' > /dev/null 2>&1 && return 0
-    get_adapter_info "$1" | grep -E '{.* AP.* managed.*}' > /dev/null 2>&1 && return 0
+    get_adapter_info "$1"  | sed -r 's/.*\{.* AP.*\} *<= *([0-9]*).*/\1/g' | sed -r 's/([0-9]*).*/\1/g' | awk '$1 > 1' > /dev/null 2>&1 && return 0
     return 1
 }
 


### PR DESCRIPTION
Proposed fix for proper multiple SSID support detection.
Please refer to issue #203 

Did test the regexp part on several iw list dumps from few wlan adapters (including Raspi3).