### PR TITLE
Update arch linux installation step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@
     cd create_ap
     make install
 
-### ArchLinux (AUR)
-    yaourt -S create_ap
+### ArchLinux
+    pacman -S create_ap
 
 ### Gentoo
     emerge layman


### PR DESCRIPTION
Hi @oblique,

since this very tool is available through the official arch linux repositories since 2016-11-02 (https://www.archlinux.org/packages/community/any/create_ap)
I have simply just updated the README file and replaced the installation on arch just with pacman instead of yaourt.

Greetings,

L0g4n.
