### PR TITLE
Fix infinite loop when run in a network namespace with NetworkManager outside the namespace

### DIFF
--- a/create_ap
+++ b/create_ap
@@ -464,8 +464,15 @@ networkmanager_is_running() {
     [[ -n "$NMCLI_OUT" ]]
 }
 
+networkmanager_knows_iface() {
+    # check if the interface $1 is known to NetworkManager
+    # an interface may exist but may not be known to NetworkManager if it is in a different network namespace than NetworkManager
+    nmcli -t -f DEVICE d 2>&1 | grep -Fxq "$1"
+}
+
 networkmanager_iface_is_unmanaged() {
     is_interface "$1" || return 2
+    networkmanager_knows_iface "$1" || return 0
     (nmcli -t -f DEVICE,STATE d 2>&1 | grep -E "^$1:unmanaged$" > /dev/null 2>&1) || return 1
 }
 


### PR DESCRIPTION
Consider the following setup:
A system runs NetworkManager (in the global namespace).
An interface (say `wlan0`) is moved to a network namespace. Within this network namespace, `create_ap` is run in order to set up an AP on `wlan0`.
`create_ap` then finds that NetworkManager is running, marks `wlan0` as unmanaged in the config file and waits for NM to reflect the change.
Since `wlan0` is in a different network namespace from NM, NM does not see the interface at all and therefore does not mark it as unmanaged. `create_ap` hangs in an infinite loop (in `networkmanager_wait_until_unmanaged`).

I fixed that by checking if an interface is known to NetworkManager. If it is not, it is considered as unmanaged.

With this patch, I had no trouble running `create_ap` in an already set up network namespace. So, this is a step towards fixing #251.