### PR TITLE
Use fixed tag for hostapd-rtl871xdrv repo

### DIFF
--- a/howto/realtek.md
+++ b/howto/realtek.md
@@ -62,7 +62,7 @@ If you're using any other distribution, run:
 ```
 git clone https://github.com/pritambaral/hostapd-rtl871xdrv.git
 cd hostapd-rtl871xdrv
-git checkout hostapd_2_5
+git checkout hostapd_2_2
 cd ..
 wget http://w1.fi/releases/hostapd-2.2.tar.gz
 tar zxvf hostapd-2.2.tar.gz

--- a/howto/realtek.md
+++ b/howto/realtek.md
@@ -61,6 +61,9 @@ If you're using any other distribution, run:
 
 ```
 git clone https://github.com/pritambaral/hostapd-rtl871xdrv.git
+cd hostapd-rtl871xdrv
+git checkout hostapd_2_5
+cd ..
 wget http://w1.fi/releases/hostapd-2.2.tar.gz
 tar zxvf hostapd-2.2.tar.gz
 cd hostapd-2.2


### PR DESCRIPTION
Because the current `master` branch no longer contains the driver_ files which are needed in the next command.