### PR TITLE
Failed to initialize lock - better error message

### DIFF
--- a/create_ap
+++ b/create_ap
@@ -1245,6 +1245,7 @@ trap "cleanup_lock" EXIT
 
 if ! init_lock; then
     echo "ERROR: Failed to initialize lock" >&2
+    echo "Try to remove /tmp/create_ap.all.lock" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Avoid that everyone have to search for the error message, find #384 and then remove the file.
Just put that in the error message directly.