### PR TITLE
Fix hostname showing directory when no hostname

### DIFF
--- a/create_ap
+++ b/create_ap
@@ -869,7 +869,7 @@ print_client() {
     if [[ -f $CONFDIR/dnsmasq.leases ]]; then
         line=$(grep " $mac " $CONFDIR/dnsmasq.leases | tail -n 1)
         ipaddr=$(echo $line | cut -d' ' -f3)
-        hostname=$(echo $line | cut -d' ' -f4)
+        hostname=$(echo "$line" | cut -d' ' -f4)
     fi
 
     [[ -z "$ipaddr" ]] && ipaddr="*"


### PR DESCRIPTION
Because `dnsmasq.leases` shows not having a hostname as `*`, bash will expand it to directory if we weren't using double quotes.

This adds double quotes to prevent expansion.

Closes #144