### PR TITLE
Fix for AC wifi to enable 80 mhz channels

### DIFF
--- a/create_ap
+++ b/create_ap
@@ -1636,6 +1636,8 @@ fi
 
 if [[ $IEEE80211AC -eq 1 ]]; then
     echo "ieee80211ac=1" >> $CONFDIR/hostapd.conf
+    echo "vht_oper_centr_freq_seg0_idx=$(($CHANNEL + 6))" >> $CONFDIR/hostapd.conf
+    echo "vht_oper_chwidth=1" >> $CONFDIR/hostapd.conf
 fi
 
 if [[ -n "$VHT_CAPAB" ]]; then


### PR DESCRIPTION
Without this fix I was getting 20 mhz channels on AC and 40 mhz channels on N. Applied I get 80 mhz channels on AC+N. It is Interesting when N=0 and AC=1 the speed is very low, but with N=1 and AC=1 I get the proper AC speeds so it seems the AC wifi can't live without N 5 ghz wifi - both have to be enabled for AC to work.

Tested on Intel(R) Dual Band Wireless AC 8265, REV=0x230
firmware version 36.77d01142.0 op_mode iwlmvm