### PR TITLE
Makefile: Make sure to use $DESTDIR when checking absolute paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,15 @@ all:
 install:
 	install -Dm755 create_ap $(DESTDIR)$(BINDIR)/create_ap
 	install -Dm644 create_ap.conf $(DESTDIR)/etc/create_ap.conf
-	[ ! -d /lib/systemd/system ] || install -Dm644 create_ap.service $(DESTDIR)$(PREFIX)/lib/systemd/system/create_ap.service
-	[ ! -e /sbin/openrc-run ] || install -Dm755 create_ap.openrc $(DESTDIR)/etc/init.d/create_ap
+	[ ! -d $(DESTDIR)/lib/systemd/system ] || install -Dm644 create_ap.service $(DESTDIR)$(PREFIX)/lib/systemd/system/create_ap.service
+	[ ! -e $(DESTDIR)/sbin/openrc-run ] || install -Dm755 create_ap.openrc $(DESTDIR)/etc/init.d/create_ap
 	install -Dm644 bash_completion $(DESTDIR)$(PREFIX)/share/bash-completion/completions/create_ap
 	install -Dm644 README.md $(DESTDIR)$(PREFIX)/share/doc/create_ap/README.md
 
 uninstall:
 	rm -f $(DESTDIR)$(BINDIR)/create_ap
 	rm -f $(DESTDIR)/etc/create_ap.conf
-	[ ! -f /lib/systemd/system/create_ap.service ] || rm -f $(DESTDIR)$(PREFIX)/lib/systemd/system/create_ap.service
-	[ ! -e /sbin/openrc-run ] || rm -f $(DESTDIR)/etc/init.d/create_ap
+	[ ! -f $(DESTDIR)$(PREFIX)/lib/systemd/system/create_ap.service ] || rm -f $(DESTDIR)$(PREFIX)/lib/systemd/system/create_ap.service
+	[ ! -e $(DESTDIR)/sbin/openrc-run ] || rm -f $(DESTDIR)/etc/init.d/create_ap
 	rm -f $(DESTDIR)$(PREFIX)/share/bash-completion/completions/create_ap
 	rm -f $(DESTDIR)$(PREFIX)/share/doc/create_ap/README.md


### PR DESCRIPTION
Fixes build issue when using Makefile to install in a Yocto filesystem or any other filesystem builder.